### PR TITLE
no cdhit

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -12,7 +12,7 @@ rule all:
       expand([
       "avasta/refgenomefilter/{sample}_refgenome_unmapped_join.fq",
       "avasta/refgenomefilter/{sample}_refgenome_unmapped_un.fq",
-      "avasta/assemblegr/{sample}"
+      "avasta/assemblerg/{sample}"
       ], sample = sample_ids)
 
 ## Modules

--- a/Snakefile
+++ b/Snakefile
@@ -10,9 +10,9 @@ include: "rules/common.smk"
 rule all:
     input:
       expand([
-      "avasta/cdhit/{sample}_cdhit_join.fa",
-      "avasta/cdhit/{sample}_cdhit_un.fa",
-      "avasta/assemble/{sample}"
+      "avasta/refgenomefilter/{sample}_refgenome_unmapped_join.fq",
+      "avasta/refgenomefilter/{sample}_refgenome_unmapped_un.fq",
+      "avasta/assemblegr/{sample}"
       ], sample = sample_ids)
 
 ## Modules

--- a/envs/biopython.yml
+++ b/envs/biopython.yml
@@ -4,6 +4,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - biopython=1.70
-  - pandas=0.23.4
-  - blast=2.7.1
+  - python>=3.5
+  - biopython
+  - pandas
+  - blast

--- a/rules/assemble.smk
+++ b/rules/assemble.smk
@@ -1,13 +1,27 @@
+
+# Split refgenome-filtered reads to joined and unjoined for spades
+rule spades_input:
+    input:
+      rules.fastq_join.output[0],
+      rules.refgenomefilter.output.fq
+    output:
+      join = "avasta/refgenomefilter/{sample}_refgenome_unmapped_join.fq",
+      un = "avasta/refgenomefilter/{sample}_refgenome_unmapped_un.fq"
+    conda:
+      "../envs/biopython.yml"
+    script:
+      "../scripts/spades_input.py"
+
 # --meta   (same as metaspades.py)
 #     This flag is recommended when assembling metagenomic data sets
 # --only-assembler
 #     Runs assembly module only
 rule assemble:
     input: 
-      rules.parse_cdhit.output.join,
-      rules.parse_cdhit.output.un
+      rules.spades_input.output.join,
+      rules.spades_input.output.un
     output: 
-      directory("avasta/assemble/{sample}")
+      directory("avasta/assemblerg/{sample}")
     params:
       options = "--meta --only-assembler"
     conda:

--- a/scripts/spades_input.py
+++ b/scripts/spades_input.py
@@ -1,0 +1,15 @@
+
+from Bio import SeqIO
+import gzip
+from common.helpers import get_ids
+
+# Save joined- and unjoined sequences into separate files for spades
+joined = SeqIO.parse(gzip.open(snakemake.input[0], "rt"), "fastq")
+joined_ids = get_ids(joined)
+
+with open(snakemake.output[0], "w") as join, open(snakemake.output[1], "w") as un:
+  for record in SeqIO.parse(snakemake.input[1], "fastq"):
+        if record.id in joined_ids:
+            SeqIO.write(record, join, 'fastq')
+        else:
+            SeqIO.write(record, un, 'fastq')


### PR DESCRIPTION
Seem like there is no point to cluster sequences before assembling. Cd-hit takes considerable time (-6 hours) and then, according to the original workflow, the number of input sequences is increased by merging top 3 matches for each representative sequence back to cd-hit output. 